### PR TITLE
25 callbacks

### DIFF
--- a/orc_api/crud/__init__.py
+++ b/orc_api/crud/__init__.py
@@ -11,6 +11,7 @@ from . import (
     settings,
     time_series,
     video,
+    video_config,
     water_level,
 )
 
@@ -25,5 +26,6 @@ __all__ = [
     "settings",
     "time_series",
     "video",
+    "video_config",
     "water_level",
 ]

--- a/orc_api/crud/cross_section.py
+++ b/orc_api/crud/cross_section.py
@@ -35,3 +35,4 @@ def update(db: Session, id: int, cross_section: dict):
     rec.update(cross_section)
     db.commit()
     db.flush()
+    return rec.first()

--- a/orc_api/crud/cross_section.py
+++ b/orc_api/crud/cross_section.py
@@ -5,9 +5,14 @@ from sqlalchemy.orm import Session
 from orc_api import db as models
 
 
+def get_query_by_id(db: Session, id: int):
+    """Get a single time series record by id."""
+    return db.query(models.CrossSection).filter(models.CrossSection.id == id)
+
+
 def get(db: Session, id: int):
     """Get a single video."""
-    query = db.query(models.CrossSection).filter(models.CrossSection.id == id)
+    query = get_query_by_id(db=db, id=id)
     if query.count() == 0:
         return
     return query.first()
@@ -19,3 +24,14 @@ def add(db: Session, cross_section: models.CrossSection) -> models.CrossSection:
     db.commit()
     db.refresh(cross_section)
     return cross_section
+
+
+def update(db: Session, id: int, cross_section: dict):
+    """Update a cross-section record using a dict of potentially modified fields."""
+    rec = get_query_by_id(db=db, id=id)
+    if not rec.first():
+        raise ValueError(f"Time series with id {id} does not exist. Create a record first.")
+    # update_data = time_series.model_dump(exclude_unset=True, exclude=["id"])
+    rec.update(cross_section)
+    db.commit()
+    db.flush()

--- a/orc_api/crud/recipe.py
+++ b/orc_api/crud/recipe.py
@@ -5,9 +5,14 @@ from sqlalchemy.orm import Session
 from orc_api import db as models
 
 
+def get_query_by_id(db: Session, id: int):
+    """Get a single time series record by id."""
+    return db.query(models.Recipe).filter(models.Recipe.id == id)
+
+
 def get(db: Session, id: int):
     """Get a single video."""
-    query = db.query(models.Recipe).filter(models.Recipe.id == id)
+    query = get_query_by_id(db=db, id=id)
     if query.count() == 0:
         return
     return query.first()
@@ -19,3 +24,15 @@ def add(db: Session, recipe: models.Recipe) -> models.Recipe:
     db.commit()
     db.refresh(recipe)
     return recipe
+
+
+def update(db: Session, id: int, recipe: dict):
+    """Update a cross-section record using a dict of potentially modified fields."""
+    rec = get_query_by_id(db=db, id=id)
+    if not rec.first():
+        raise ValueError(f"Time series with id {id} does not exist. Create a record first.")
+    # update_data = time_series.model_dump(exclude_unset=True, exclude=["id"])
+    rec.update(recipe)
+    db.commit()
+    db.flush()
+    return rec.first()

--- a/orc_api/crud/recipe.py
+++ b/orc_api/crud/recipe.py
@@ -30,7 +30,7 @@ def update(db: Session, id: int, recipe: dict):
     """Update a cross-section record using a dict of potentially modified fields."""
     rec = get_query_by_id(db=db, id=id)
     if not rec.first():
-        raise ValueError(f"Time series with id {id} does not exist. Create a record first.")
+        raise ValueError(f"Recipe with id {id} does not exist. Create a record first.")
     # update_data = time_series.model_dump(exclude_unset=True, exclude=["id"])
     rec.update(recipe)
     db.commit()

--- a/orc_api/crud/time_series.py
+++ b/orc_api/crud/time_series.py
@@ -48,3 +48,4 @@ def update(db: Session, id: int, time_series: dict):
     rec.update(time_series)
     db.commit()
     db.flush()
+    return rec.first()

--- a/orc_api/crud/video.py
+++ b/orc_api/crud/video.py
@@ -87,7 +87,7 @@ def delete_start_stop(db: Session, start: datetime, stop: datetime):
     return
 
 
-def create(db: Session, video: models.Video) -> models.Video:
+def add(db: Session, video: models.Video) -> models.Video:
     """Add a video to the database."""
     db.add(video)
     db.commit()

--- a/orc_api/crud/video.py
+++ b/orc_api/crud/video.py
@@ -104,3 +104,4 @@ def update(db: Session, id: int, video: dict):
     rec.update(video)
     db.commit()
     db.flush()
+    return rec.first()

--- a/orc_api/crud/video_config.py
+++ b/orc_api/crud/video_config.py
@@ -1,0 +1,47 @@
+"""CRUD operations for video configs."""
+
+from sqlalchemy.orm import Session
+
+from orc_api import db as models
+
+
+def get_query_by_id(db: Session, id: int):
+    """Get a single video config in a query (e.g. for updating."""
+    return db.query(models.VideoConfig).filter(models.VideoConfig.id == id)
+
+
+def get(db: Session, id: int):
+    """Get a single video."""
+    query = get_query_by_id(db=db, id=id)
+    if query.count() == 0:
+        return
+    return query.first()
+
+
+def delete(db: Session, id: int):
+    """Delete a single video."""
+    query = db.query(models.VideoConfig).filter(models.VideoConfig.id == id)
+    if query.count() == 0:
+        raise ValueError(f"Video with id {id} does not exist.")
+    video_config = query.first()
+    db.delete(video_config)
+    db.commit()
+    return
+
+
+def add(db: Session, video_config: models.VideoConfig) -> models.VideoConfig:
+    """Add a video to the database."""
+    db.add(video_config)
+    db.commit()
+    db.refresh(video_config)
+    return video_config
+
+
+def update(db: Session, id: int, video_config: dict):
+    """Update a video record using the VideoResponse instance."""
+    rec = get_query_by_id(db=db, id=id)
+    if not rec.first():
+        raise ValueError(f"Video config with id {id} does not exist. Create a record first.")
+    rec.update(video_config)
+    db.commit()
+    db.flush()

--- a/orc_api/crud/video_config.py
+++ b/orc_api/crud/video_config.py
@@ -45,3 +45,4 @@ def update(db: Session, id: int, video_config: dict):
     rec.update(video_config)
     db.commit()
     db.flush()
+    return rec.first()

--- a/orc_api/db/base.py
+++ b/orc_api/db/base.py
@@ -16,6 +16,7 @@ class SyncStatus(enum.Enum):
     LOCAL = 1
     SYNCED = 2
     UPDATED = 3
+    FAILED = 4
 
 
 class RemoteBase(Base):

--- a/orc_api/routers/video.py
+++ b/orc_api/routers/video.py
@@ -169,7 +169,7 @@ async def upload_video(
     video_instance = Video(**video.model_dump())
 
     # Save to database
-    video_instance = crud.video.create(db=db, video=video_instance)
+    video_instance = crud.video.add(db=db, video=video_instance)
 
     # now the video has an ID and we can create a logical storage location
     file_dir = os.path.join(UPLOAD_DIRECTORY, "videos", timestamp.strftime("%Y%m%d"), str(video_instance.id))

--- a/orc_api/schemas/__init__.py
+++ b/orc_api/schemas/__init__.py
@@ -1,6 +1,16 @@
 """Schemas for ORC-OS."""
 
-from . import callback_url, camera_config, cross_section, device, disk_management, settings, video, water_level
+from . import (
+    callback_url,
+    camera_config,
+    cross_section,
+    device,
+    disk_management,
+    settings,
+    video,
+    video_config,
+    water_level,
+)
 
 __all__ = [
     "callback_url",
@@ -10,5 +20,6 @@ __all__ = [
     "disk_management",
     "settings",
     "video",
+    "video_config",
     "water_level",
 ]

--- a/orc_api/schemas/base.py
+++ b/orc_api/schemas/base.py
@@ -29,7 +29,7 @@ class RemoteModel(BaseModel):
         # get all callback functionalities in place.
         if self.remote_id is not None:
             # add the id to the end point and only patch existing record
-            r = callback_url.patch(endpoint=endpoint + f"{self.remote_id}", data=data, files=files)
+            r = callback_url.patch(endpoint=endpoint + f"{self.remote_id}/", data=data, files=files)
         else:
             r = callback_url.post(endpoint=endpoint, data=data, files=files)
         # put back the remote id

--- a/orc_api/schemas/base.py
+++ b/orc_api/schemas/base.py
@@ -16,11 +16,11 @@ class RemoteModel(BaseModel):
     """Base model for a cross-section."""
 
     id: int = Field(description="Record ID")
-    created_at: datetime = Field(description="Creation date")
+    created_at: Optional[datetime] = Field(default=None, description="Creation date")
     remote_id: Optional[int] = Field(default=None, description="Record ID on the remote server")
     sync_status: SyncStatus = Field(default=SyncStatus.LOCAL, description="Status of the record on the remote server")
 
-    def callback(self, endpoint: str, data=None, files=None):
+    def sync_remote(self, endpoint: str, data=None, files=None):
         """Send remote updates to LiveORC API."""
         db = get_session()
         callback_url = CallbackUrlResponse.model_validate(crud.callback_url.get(db))
@@ -28,5 +28,19 @@ class RemoteModel(BaseModel):
             raise ValueError("No callback URL configured. Please ensure you first gain access to a LiveORC API.")
         # get all callback functionalities in place.
         if self.remote_id is not None:
-            data["id"] = self.remote_id
-        callback_url.post(endpoint=endpoint, data=data, files=files)
+            # add the id to the end point and only patch existing record
+            r = callback_url.patch(endpoint=endpoint + f"{self.remote_id}", data=data, files=files)
+        else:
+            r = callback_url.post(endpoint=endpoint, data=data, files=files)
+        # put back the remote id
+        if r.status_code in [200, 201]:
+            # success
+            # get the ids back in the right order
+            response_data = r.json()
+            response_data["remote_id"] = response_data.pop("id")
+            response_data["sync_status"] = SyncStatus.SYNCED.value
+            response_data["id"] = self.id
+            return response_data
+        else:
+            self.sync_status = SyncStatus.FAILED
+            raise ValueError(f"Remote update failed with status code {r.status_code}.")

--- a/orc_api/schemas/base.py
+++ b/orc_api/schemas/base.py
@@ -1,0 +1,32 @@
+"""Pydantic base model for remote syncing schemas."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from orc_api import crud
+from orc_api.database import get_session
+from orc_api.db.base import SyncStatus
+from orc_api.schemas.callback_url import CallbackUrlResponse
+
+
+# Default fields of Pydantic model for responses of Remote models
+class RemoteModel(BaseModel):
+    """Base model for a cross-section."""
+
+    id: int = Field(description="Record ID")
+    created_at: datetime = Field(description="Creation date")
+    remote_id: Optional[int] = Field(default=None, description="Record ID on the remote server")
+    sync_status: SyncStatus = Field(default=SyncStatus.LOCAL, description="Status of the record on the remote server")
+
+    def callback(self, endpoint: str, data=None, files=None):
+        """Send remote updates to LiveORC API."""
+        db = get_session()
+        callback_url = CallbackUrlResponse.model_validate(crud.callback_url.get(db))
+        if callback_url is None:
+            raise ValueError("No callback URL configured. Please ensure you first gain access to a LiveORC API.")
+        # get all callback functionalities in place.
+        if self.remote_id is not None:
+            data["id"] = self.remote_id
+        callback_url.post(endpoint=endpoint, data=data, files=files)

--- a/orc_api/schemas/base.py
+++ b/orc_api/schemas/base.py
@@ -20,7 +20,7 @@ class RemoteModel(BaseModel):
     remote_id: Optional[int] = Field(default=None, description="Record ID on the remote server")
     sync_status: SyncStatus = Field(default=SyncStatus.LOCAL, description="Status of the record on the remote server")
 
-    def sync_remote(self, endpoint: str, data=None, files=None):
+    def sync_remote(self, endpoint: str, data=None, json=None, files=None):
         """Send remote updates to LiveORC API."""
         db = get_session()
         callback_url = CallbackUrlResponse.model_validate(crud.callback_url.get(db))
@@ -29,9 +29,9 @@ class RemoteModel(BaseModel):
         # get all callback functionalities in place.
         if self.remote_id is not None:
             # add the id to the end point and only patch existing record
-            r = callback_url.patch(endpoint=endpoint + f"{self.remote_id}/", data=data, files=files)
+            r = callback_url.patch(endpoint=endpoint + f"{self.remote_id}/", data=data, json=json, files=files)
         else:
-            r = callback_url.post(endpoint=endpoint, data=data, files=files)
+            r = callback_url.post(endpoint=endpoint, data=data, json=json, files=files)
         # put back the remote id
         if r.status_code in [200, 201]:
             # success

--- a/orc_api/schemas/callback_url.py
+++ b/orc_api/schemas/callback_url.py
@@ -75,24 +75,34 @@ class CallbackUrlResponse(CallbackUrlBase):
         new_callback_url["url"] = str(new_callback_url["url"])
         crud.callback_url.add(db, models.CallbackUrl(**new_callback_url))
 
-    def get(self, end_point, data=None):
+    def get(self, endpoint, data=None):
         """Perform GET request on end point with optional data."""
         data = {} if data is None else data
-        url = urljoin(str(self.url), end_point)
+        url = urljoin(str(self.url), endpoint)
         if self.token_expiration < datetime.now():
             # first get a new token
             self.get_set_refresh_tokens()
-        return requests.get(url, data=data, headers=self.headers, timeout=5)
+        return requests.get(url, json=data, headers=self.headers, timeout=5)
 
-    def post(self, end_point, data=None, files=None):
+    def patch(self, endpoint, data=None, files=None):
+        """Perform PATCH request on end point with optional data and files."""
+        data = {} if data is None else data
+        files = {} if files is None else files
+        url = urljoin(str(self.url), endpoint)
+        if self.token_expiration < datetime.now():
+            # first get a new token
+            self.get_set_refresh_tokens()
+        return requests.patch(url, headers=self.headers, json=data, files=files, timeout=5)
+
+    def post(self, endpoint, data=None, files=None):
         """Perform POST request on end point with optional data and files."""
         data = {} if data is None else data
         files = {} if files is None else files
-        url = urljoin(str(self.url), end_point)
+        url = urljoin(str(self.url), endpoint)
         if self.token_expiration < datetime.now():
             # first get a new token
             self.get_set_refresh_tokens()
-        return requests.post(url, headers=self.headers, data=data, files=files, timeout=5)
+        return requests.post(url, headers=self.headers, json=data, files=files, timeout=5)
 
     def get_online_status(self):
         """Check if the callback URL is online and the token is valid, return health parameters."""
@@ -128,7 +138,7 @@ class CallbackUrlCreate(CallbackUrlBase):
         """Get tokens for the callback URL using email/password."""
         url = urljoin(str(self.url), "/api/token/")
         data = {"email": self.user, "password": self.password}
-        response = requests.post(url, data=data)
+        response = requests.post(url, data=data, timeout=5)
         return response
 
 

--- a/orc_api/schemas/callback_url.py
+++ b/orc_api/schemas/callback_url.py
@@ -94,15 +94,16 @@ class CallbackUrlResponse(CallbackUrlBase):
             self.get_set_refresh_tokens()
         return requests.patch(url, headers=self.headers, json=data, files=files, timeout=5)
 
-    def post(self, endpoint, data=None, files=None):
+    def post(self, endpoint, data=None, json=None, files=None):
         """Perform POST request on end point with optional data and files."""
-        data = {} if data is None else data
-        files = {} if files is None else files
+        # data = {} if data is None else data
+        # files = {} if files is None else files
+        # json = {} if json is None else json
         url = urljoin(str(self.url), endpoint)
         if self.token_expiration < datetime.now():
             # first get a new token
             self.get_set_refresh_tokens()
-        return requests.post(url, headers=self.headers, json=data, files=files, timeout=5)
+        return requests.post(url, headers=self.headers, json=json, data=data, files=files, timeout=5)
 
     def get_online_status(self):
         """Check if the callback URL is online and the token is valid, return health parameters."""

--- a/orc_api/schemas/camera_config.py
+++ b/orc_api/schemas/camera_config.py
@@ -35,6 +35,19 @@ class CameraConfigResponse(CameraConfigBase, RemoteModel):
 
     id: int = Field(description="CameraConfig ID")
 
+    def sync_remote(self, site: int):
+        """Send the recipe to LiveORC API.
+
+        Recipes belong to an institute, hence also the institute ID is required.
+        """
+        # endpoint = f"/api/site/{site}/cameraconfig/"
+        # data = {
+        #     "name": self.name,
+        #     "camera_config": self.data,
+        # }
+        # TODO: this end point is not yet implemented, as it requires a restructuring on LiveORC
+        pass
+
 
 class CameraConfigCreate(CameraConfigBase):
     """Create model for camera configuration."""

--- a/orc_api/schemas/camera_config.py
+++ b/orc_api/schemas/camera_config.py
@@ -1,13 +1,12 @@
 """Pydantic models for camera configurations."""
 
 import warnings
-from datetime import datetime
 from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 from pyproj.crs import CRS
 
-from orc_api.db.base import SyncStatus
+from orc_api.schemas.base import RemoteModel
 
 # Alternatively, print traceback for warnings without halting execution
 warnings.simplefilter("always", DeprecationWarning)
@@ -31,15 +30,10 @@ class CameraConfigBase(BaseModel):
         return _crs
 
 
-class CameraConfigResponse(CameraConfigBase):
+class CameraConfigResponse(CameraConfigBase, RemoteModel):
     """Response model for camera configuration."""
 
-    id: int = Field(description="Camera configuration ID")
-    created_at: datetime = Field(description="Creation date")
-    remote_id: Optional[int] = Field(default=None, description="ID of the camera configuration on the remote server")
-    sync_status: SyncStatus = Field(
-        default=SyncStatus.LOCAL, description="Status of the cmaera configuration on the remote server"
-    )
+    id: int = Field(description="CameraConfig ID")
 
 
 class CameraConfigCreate(CameraConfigBase):

--- a/orc_api/schemas/cross_section.py
+++ b/orc_api/schemas/cross_section.py
@@ -60,7 +60,7 @@ class CrossSectionResponse(CrossSectionBase, RemoteModel):
             # response_data.pop("site")
             # update schema instance
             update_cross_section = CrossSectionResponse.model_validate(response_data)
-            crud.cross_section.update(
+            r = crud.cross_section.update(
                 get_session(), id=self.id, cross_section=update_cross_section.model_dump(exclude_unset=True)
             )
-            return update_cross_section
+            return CrossSectionResponse.model_validate(r)

--- a/orc_api/schemas/cross_section.py
+++ b/orc_api/schemas/cross_section.py
@@ -56,8 +56,6 @@ class CrossSectionResponse(CrossSectionBase, RemoteModel):
         if response_data is not None:
             # patch the record in the database, where necessary
             response_data["features"] = response_data.pop("data")
-            # remove site from response
-            # response_data.pop("site")
             # update schema instance
             update_cross_section = CrossSectionResponse.model_validate(response_data)
             r = crud.cross_section.update(

--- a/orc_api/schemas/cross_section.py
+++ b/orc_api/schemas/cross_section.py
@@ -52,7 +52,7 @@ class CrossSectionResponse(CrossSectionBase, RemoteModel):
             "data": self.features,
         }
         # sync remotely with the updated data, following the LiveORC end point naming
-        response_data = super().sync_remote(endpoint=endpoint, data=data)
+        response_data = super().sync_remote(endpoint=endpoint, json=data)
         if response_data is not None:
             # patch the record in the database, where necessary
             response_data["features"] = response_data.pop("data")

--- a/orc_api/schemas/cross_section.py
+++ b/orc_api/schemas/cross_section.py
@@ -1,18 +1,17 @@
 """Pydantic models for cross sections."""
 
 from datetime import datetime
-from typing import Optional
 
 import geopandas as gpd
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pyorc.cli.cli_utils import read_shape_as_gdf
 
-from orc_api.db.base import SyncStatus
+from orc_api.schemas.base import RemoteModel
 
 
 # Pydantic model for responses
 class CrossSectionBase(BaseModel):
-    """Base model for a cross section."""
+    """Base model for a cross-section."""
 
     timestamp: datetime = Field(default=datetime.now(), description="Moment at which cross section was measured.")
     name: str = Field(default=None, description="Free recognizable description of cross section.")
@@ -27,22 +26,27 @@ class CrossSectionBase(BaseModel):
 
     @property
     def gdf(self):
-        """Return the cross section as a GeoDataFrame."""
+        """Return the cross-section as a GeoDataFrame."""
         crs = None if "crs" not in self.features else self.features["crs"]["properties"]["name"]
         return gpd.GeoDataFrame.from_features(self.features, crs=crs)
 
     @property
     def crs(self):
-        """Return the coordinate reference system of the cross section."""
+        """Return the coordinate reference system of the cross-section."""
         return self.gdf.crs
 
 
-class CrossSectionResponse(CrossSectionBase):
-    """Response model for a cross section."""
+class CrossSectionResponse(CrossSectionBase, RemoteModel):
+    """Response model for a cross-section."""
 
-    id: int = Field(description="Cross section ID")
-    created_at: datetime = Field(description="Creation date")
-    remote_id: Optional[int] = Field(default=None, description="ID of the cross section on the remote server")
-    sync_status: SyncStatus = Field(
-        default=SyncStatus.LOCAL, description="Status of the cross section on the remote server"
-    )
+    id: int = Field(description="CrossSection ID")
+
+    def callback(self, site: int, **kwargs):
+        """Send the cross-section to LiveORC API."""
+        endpoint = f"/api/site/{site}/profile/"
+        data = {
+            "name": self.name,
+            "timestamp": self.timestamp,
+            "data": self.features,
+        }
+        super().callback(endpoint=endpoint, data=data)

--- a/orc_api/schemas/recipe.py
+++ b/orc_api/schemas/recipe.py
@@ -33,7 +33,7 @@ class RecipeResponse(RecipeBase, RemoteModel):
             "institute": institute,
         }
         # sync remotely with the updated data, following the LiveORC end point naming
-        response_data = super().sync_remote(endpoint=endpoint, data=data)
+        response_data = super().sync_remote(endpoint=endpoint, json=data)
         if response_data is not None:
             # patch the record in the database, where necessary
             # update schema instance

--- a/orc_api/schemas/recipe.py
+++ b/orc_api/schemas/recipe.py
@@ -2,6 +2,8 @@
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from orc_api import crud
+from orc_api.database import get_session
 from orc_api.schemas.base import RemoteModel
 
 
@@ -18,3 +20,23 @@ class RecipeResponse(RecipeBase, RemoteModel):
     """Response model for a recipe."""
 
     id: int = Field(description="Recipe ID")
+
+    def sync_remote(self, institute: int):
+        """Send the recipe to LiveORC API.
+
+        Recipes belong to an institute, hence also the institute ID is required.
+        """
+        endpoint = "/api/recipe/"
+        data = {
+            "name": self.name,
+            "data": self.data,
+            "institute": institute,
+        }
+        # sync remotely with the updated data, following the LiveORC end point naming
+        response_data = super().sync_remote(endpoint=endpoint, data=data)
+        if response_data is not None:
+            # patch the record in the database, where necessary
+            # update schema instance
+            update_recipe = RecipeResponse.model_validate(response_data)
+            r = crud.recipe.update(get_session(), id=self.id, recipe=update_recipe.model_dump(exclude_unset=True))
+            return RecipeResponse.model_validate(r)

--- a/orc_api/schemas/recipe.py
+++ b/orc_api/schemas/recipe.py
@@ -1,11 +1,8 @@
 """Pydantic models for recipes."""
 
-from datetime import datetime
-from typing import Optional
-
 from pydantic import BaseModel, ConfigDict, Field
 
-from orc_api.db.base import SyncStatus
+from orc_api.schemas.base import RemoteModel
 
 
 # Pydantic model for responses
@@ -17,10 +14,7 @@ class RecipeBase(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
 
-class RecipeResponse(RecipeBase):
+class RecipeResponse(RecipeBase, RemoteModel):
     """Response model for a recipe."""
 
     id: int = Field(description="Recipe ID")
-    created_at: datetime = Field(description="Creation date")
-    remote_id: Optional[int] = Field(default=None, description="ID of the recipe on the remote server")
-    sync_status: SyncStatus = Field(default=SyncStatus.LOCAL, description="Status of the recipe on the remote server")

--- a/orc_api/schemas/time_series.py
+++ b/orc_api/schemas/time_series.py
@@ -5,11 +5,14 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
+from orc_api.schemas.base import RemoteModel
+
 
 # Pydantic model for responses
 class TimeSeriesBase(BaseModel):
     """Base model for a time series."""
 
+    timestamp: datetime = Field(description="Timestamp of the video.")
     h: Optional[float] = Field(
         default=None, description="Value of water level in meter, referenced against local datum [m]"
     )
@@ -42,31 +45,7 @@ class TimeSeriesCreate(TimeSeriesBase):
     pass
 
 
-class TimeSeriesResponse(TimeSeriesBase):
+class TimeSeriesResponse(TimeSeriesBase, RemoteModel):
     """Response model for a time series."""
 
-    id: int = Field(description="Time series ID")
-    timestamp: datetime = Field(description="Timestamp of the video.")
-    h: Optional[float] = Field(
-        default=None, description="Value of water level in meter, referenced against local datum [m]"
-    )
-    q_05: Optional[float] = Field(
-        default=None, description="Streamflow with probability of non-exceedance of 5% [m3/s]"
-    )
-    q_25: Optional[float] = Field(
-        default=None, description="Streamflow with probability of non-exceedance of 25% [m3/s]"
-    )
-    q_50: Optional[float] = Field(
-        default=None, description="Streamflow with probability of non-exceedance of 50% [m3/s]"
-    )
-    q_75: Optional[float] = Field(
-        default=None, description="Streamflow with probability of non-exceedance of 75% [m3/s]"
-    )
-    q_95: Optional[float] = Field(
-        default=None, description="Streamflow with probability of non-exceedance of 95% [m3/s]"
-    )
-    wetted_surface: Optional[float] = Field(default=None, description="Wetted surface area with given water level [m2]")
-    wetted_perimeter: Optional[float] = Field(default=None, description="Wetted perimeter with given water level [m]")
-    fraction_velocimetry: Optional[float] = Field(
-        default=None, description="Fraction of discharge resolved using velocimetry [-]"
-    )
+    id: int = Field(description="TimeSeries ID")

--- a/orc_api/schemas/time_series.py
+++ b/orc_api/schemas/time_series.py
@@ -58,7 +58,9 @@ class TimeSeriesResponse(TimeSeriesBase, RemoteModel):
         Recipes belong to an institute, hence also the institute ID is required.
         """
         endpoint = f"/api/site/{site}/timeseries/"
-        data = self.model_dump(exclude_unset=True, exclude=["id", "remote_id", "created_at", "sync_status"])
+        data = self.model_dump(
+            exclude_unset=True, exclude_none=True, exclude=["id", "remote_id", "created_at", "sync_status"], mode="json"
+        )
 
         # sync remotely with the updated data, following the LiveORC end point naming
         response_data = super().sync_remote(endpoint=endpoint, data=data)

--- a/orc_api/schemas/time_series.py
+++ b/orc_api/schemas/time_series.py
@@ -63,7 +63,7 @@ class TimeSeriesResponse(TimeSeriesBase, RemoteModel):
         )
 
         # sync remotely with the updated data, following the LiveORC end point naming
-        response_data = super().sync_remote(endpoint=endpoint, data=data)
+        response_data = super().sync_remote(endpoint=endpoint, json=data)
         if response_data is not None:
             # patch the record in the database, where necessary
             # update schema instance

--- a/orc_api/schemas/video.py
+++ b/orc_api/schemas/video.py
@@ -4,7 +4,7 @@ import glob
 import json
 import os
 from datetime import datetime
-from typing import Optional, Union
+from typing import Optional
 
 import numpy as np
 import xarray as xr
@@ -15,7 +15,7 @@ from orc_api import crud
 from orc_api import db as models
 from orc_api.database import get_session
 from orc_api.log import logger
-from orc_api.schemas.time_series import TimeSeriesBase, TimeSeriesResponse
+from orc_api.schemas.time_series import TimeSeriesResponse
 from orc_api.schemas.video_config import VideoConfigBase
 
 
@@ -42,7 +42,7 @@ class VideoResponse(VideoBase):
     image: Optional[str] = Field(default=None, description="Image file name of the video.")
     thumbnail: Optional[str] = Field(default=None, description="Thumbnail file name of the video.")
     status: Optional[models.VideoStatus] = Field(default=models.VideoStatus.NEW, description="Status of the video.")
-    time_series: Optional[Union[TimeSeriesResponse, TimeSeriesBase]] = TimeSeriesBase()
+    time_series: Optional[TimeSeriesResponse] = Field(default=None, description="Time series attached to video.")
     sync_status: Optional[models.SyncStatus] = Field(
         default=models.SyncStatus.LOCAL, description="Status of the video to LiveORC server."
     )

--- a/orc_api/schemas/video.py
+++ b/orc_api/schemas/video.py
@@ -165,15 +165,17 @@ class VideoResponse(VideoBase, RemoteModel):
             files["image"] = (self.image, open(self.get_image_file(base_path=base_path), "rb"))
         response_data = super().sync_remote(endpoint=endpoint, data=data, files=files)
         if response_data is not None:
-            response_data.pop("camera_config")
-            response_data.pop("created_at")
-            response_data.pop("file")  # remove all refs to file media, as these are different on the remote server
-            response_data.pop("image")
-            response_data.pop("keyframe")
-            response_data.pop("thumbnail")
-            response_data.pop("project")
-            response_data.pop("time_series")
-            response_data.pop("creator")
+            response_data.pop("camera_config", None)
+            response_data.pop("created_at", None)
+            response_data.pop(
+                "file", None
+            )  # remove all refs to file media, as these are different on the remote server
+            response_data.pop("image", None)
+            response_data.pop("keyframe", None)
+            response_data.pop("thumbnail", None)
+            response_data.pop("project", None)
+            response_data.pop("time_series", None)
+            response_data.pop("creator", None)
             response_data["video_config_id"] = self.video_config_id
             response_data["time_series_id"] = self.time_series_id
             # patch the record in the database, where necessary

--- a/orc_api/schemas/video_config.py
+++ b/orc_api/schemas/video_config.py
@@ -155,11 +155,11 @@ class VideoConfigResponse(VideoConfigBase, RemoteModel):
             "profile": self.cross_section.remote_id,
         }
         # sync remotely with the updated data, following the LiveORC end point naming
-        response_data = super().sync_remote(endpoint=endpoint, data=data)
+        response_data = super().sync_remote(endpoint=endpoint, json=data)
         # ids of recipe and profile are already known and remote ids already updated, so remove
         if response_data is not None:
-            response_data.pop("recipe")
-            response_data.pop("profile")
+            response_data.pop("recipe")  # these are different on LiveORC, as they are with a datetime stamp
+            response_data.pop("profile")  # same
             response_data.pop("camera_config")
             response_data.pop("server")
             response_data["camera_config_id"] = self.camera_config_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ authors = [
     {name = "Hessel Winsemius", email = "winsemius@rainbowsensing.com"},
 ]
 dependencies = [
-    "geojson-pydantic",
     "pillow",
     "pyopenrivercam>=0.8.5",
     "sqlalchemy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-geojson-pydantic
 sqlalchemy
 fastapi[standard]
 pillow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import json
 import os
+from datetime import datetime, timedelta
 
 import pytest
 import yaml
@@ -91,7 +92,12 @@ def session_config(session_empty, tmpdir):
     )
     disk_management_instance = db.DiskManagement(home_folder=str(tmpdir))
     water_level_settings_instance = db.WaterLevelSettings()
-    callback_url_instance = db.CallbackUrl()
+    callback_url_instance = db.CallbackUrl(
+        token_refresh_end_point="/api/token/refresh/",
+        token_refresh="some_token",
+        token_access="some_other_token",
+        token_expiration=datetime.now() + timedelta(days=1),
+    )
     session.add(device_instance)
     session.add(settings_instance)
     session.add(disk_management_instance)

--- a/tests/test_crud/conftest.py
+++ b/tests/test_crud/conftest.py
@@ -30,7 +30,7 @@ def session_video(session_config, vid_file, monkeypatch):
     # give a timestamp too far before the first available time stamp time series
     timestamp = datetime.now()
     video = db.Video(file=vid_file, timestamp=timestamp)
-    _ = crud.video.create(session_config, video)
+    _ = crud.video.add(session_config, video)
     return session_config
 
 

--- a/tests/test_crud/test_video.py
+++ b/tests/test_crud/test_video.py
@@ -11,7 +11,7 @@ def test_video_add(session_water_levels, vid_file, monkeypatch):
         file=vid_file,
         # timestamp=datetime.now()
     )
-    video = crud_video.create(session_water_levels, video)
+    video = crud_video.add(session_water_levels, video)
     # test if video has a water level attached
     assert video.time_series_id == 5  # should be the middle time stamp
     assert video.id == 1
@@ -26,7 +26,7 @@ def test_video_add_no_water_level_found(session_water_levels, vid_file, monkeypa
     # give a timestamp too far before the first available time stamp time series
     timestamp = datetime.now() + timedelta(hours=-24)
     video = db.Video(file=vid_file, timestamp=timestamp)
-    video = crud_video.create(session_water_levels, video)
+    video = crud_video.add(session_water_levels, video)
     # test if video has a water level attached
     assert video.id == 1
     assert video.time_series_id is None

--- a/tests/test_schemas/conftest.py
+++ b/tests/test_schemas/conftest.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from orc_api import crud
 from orc_api.db import CameraConfig, CrossSection, Recipe, TimeSeries, Video, VideoConfig
 from orc_api.schemas.video import VideoResponse
-from orc_api.schemas.video_config import VideoConfigBase
+from orc_api.schemas.video_config import VideoConfigResponse
 
 
 @pytest.fixture
@@ -106,7 +106,7 @@ def session_video_with_config(session_video_config, monkeypatch):
 @pytest.fixture
 def video_config_response(session_video_config: Session):
     vc_rec = session_video_config.query(VideoConfig).first()
-    return VideoConfigBase.model_validate(vc_rec)
+    return VideoConfigResponse.model_validate(vc_rec)
 
 
 @pytest.fixture

--- a/tests/test_schemas/conftest.py
+++ b/tests/test_schemas/conftest.py
@@ -81,7 +81,7 @@ def session_video_no_ts_with_config(session_video_config, monkeypatch):
         video_config_id=vc_rec.id,
         file=os.path.split(sample_data.get_hommerich_dataset())[1],
     )
-    video = crud.video.create(session_video_config, video)
+    video = crud.video.add(session_video_config, video)
     return session_video_config
 
 
@@ -98,7 +98,7 @@ def session_video_with_config(session_video_config, monkeypatch):
         video_config_id=vc_rec.id,
         file=os.path.split(sample_data.get_hommerich_dataset())[1],
     )
-    video = crud.video.create(session_video_config, video)
+    video = crud.video.add(session_video_config, video)
     print(video)
     return session_video_config
 

--- a/tests/test_schemas/conftest.py
+++ b/tests/test_schemas/conftest.py
@@ -13,31 +13,31 @@ from orc_api.schemas.video_config import VideoConfigResponse
 
 
 @pytest.fixture
-def session_cam_config(session_empty, cam_config):
+def session_cam_config(session_config, cam_config):
     c = CameraConfig(name="some camera config", data=cam_config)
-    session_empty.add(c)
-    session_empty.commit()
-    session_empty.refresh(c)
-    return session_empty
+    session_config.add(c)
+    session_config.commit()
+    session_config.refresh(c)
+    return session_config
 
 
 @pytest.fixture
-def session_cross_section(session_empty, cross_section):
+def session_cross_section(session_config, cross_section):
     cs = CrossSection(name="some cross section", features=cross_section)
-    session_empty.add(cs)
-    session_empty.commit()
-    session_empty.refresh(cs)
-    return session_empty
+    session_config.add(cs)
+    session_config.commit()
+    session_config.refresh(cs)
+    return session_config
 
 
 @pytest.fixture
-def session_recipe(session_empty, recipe):
+def session_recipe(session_config, recipe):
     recipe = json.loads(recipe)
     r = Recipe(name="some recipe", data=recipe)
-    session_empty.add(r)
-    session_empty.commit()
-    session_empty.refresh(r)
-    return session_empty
+    session_config.add(r)
+    session_config.commit()
+    session_config.refresh(r)
+    return session_config
 
 
 @pytest.fixture

--- a/tests/test_schemas/test_cross_section_schemas.py
+++ b/tests/test_schemas/test_cross_section_schemas.py
@@ -1,8 +1,25 @@
+import os
+from datetime import datetime
+
 import pytest
 from sqlalchemy.orm import Session
 
-from orc_api.db import CrossSection
+from orc_api import crud
+from orc_api.db import CallbackUrl, CrossSection, SyncStatus
+from orc_api.schemas.callback_url import CallbackUrlCreate, CallbackUrlResponse
 from orc_api.schemas.cross_section import CrossSectionResponse
+
+
+def liveorc_access():
+    # check if env variables are present to perform liveorc test
+    access = True
+    if os.getenv("LIVEORC_URL") is None:
+        access = False
+    if os.getenv("LIVEORC_EMAIL") is None:
+        access = False
+    if os.getenv("LIVEORC_PASSWORD") is None:
+        access = False
+    return access
 
 
 @pytest.fixture
@@ -15,3 +32,84 @@ def cross_section_response(session_cross_section: Session):
 def test_cross_section_schema(cross_section_response):
     # check if crs is available
     assert cross_section_response.crs is not None
+
+
+def test_cross_section_sync(session_cross_section, cross_section_response, monkeypatch):
+    """Test for syncing a cross-section to remote API (real response is mocked)."""
+    # let's assume we are posting on site 1
+    site = 1
+
+    def mock_post(self, endpoint: str, data=None, files=None):
+        class MockResponse:
+            status_code = 201
+
+            def json(self):
+                return {
+                    "id": 3,
+                    "created_at": datetime.now().strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "name": cross_section_response.name,
+                    "data": cross_section_response.features,
+                    "timestamp": cross_section_response.timestamp.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "site": site,
+                }
+
+        return MockResponse()
+
+    monkeypatch.setattr(CallbackUrlResponse, "post", mock_post)
+    monkeypatch.setattr("orc_api.schemas.cross_section.get_session", lambda: session_cross_section)
+    cross_section_update = cross_section_response.sync_remote(site=1)
+    assert cross_section_update.remote_id == 3
+    assert cross_section_update.sync_status == SyncStatus.SYNCED
+
+
+def test_cross_section_sync_not_permitted(session_cross_section, cross_section_response, monkeypatch):
+    """Test for syncing a cross-section to remote API (real response is mocked)."""
+    # let's assume we are posting on site 1
+    site = 1
+
+    def mock_post(self, endpoint: str, data=None, files=None):
+        class MockResponse:
+            status_code = 403
+
+        return MockResponse()
+
+    monkeypatch.setattr(CallbackUrlResponse, "post", mock_post)
+    monkeypatch.setattr("orc_api.schemas.cross_section.get_session", lambda: session_cross_section)
+    with pytest.raises(ValueError, match="Remote update failed with status code 403."):
+        _ = cross_section_response.sync_remote(site=site)
+
+
+@pytest.mark.skipif(
+    liveorc_access() == False, reason="This test requires LIVEORC_URL, LIVEORC_EMAIL and LIVEORC_PASSWORD to be set"
+)
+def test_cross_section_sync_real_server(session_cross_section, cross_section_response, monkeypatch):
+    """Test for syncing a cross-section to a real remote API.
+
+    This requires setting LIVEORC_URL, LIVEORC_EMAIL and LIVEORC_PASSWORD environment variables.
+    You must have access to the remote API to run this test and have site=1 available on the remote API.
+    """
+    # first patch the liveorc access
+    callback_create = CallbackUrlCreate(
+        url=os.getenv("LIVEORC_URL"),
+        user=os.getenv("LIVEORC_EMAIL"),
+        password=os.getenv("LIVEORC_PASSWORD"),
+    )
+    tokens = callback_create.get_tokens().json()
+    new_callback_dict = callback_create.model_dump(exclude_none=True, mode="json", exclude={"id", "password", "user"})
+    # add our newly found information from LiveORC server
+    new_callback_dict.update(
+        {
+            "token_access": tokens["access"],
+            "token_refresh": tokens["refresh"],
+            "token_expiration": callback_create.get_token_expiration(),
+        }
+    )
+    new_callback_url = CallbackUrl(**new_callback_dict)
+    crud.callback_url.add(session_cross_section, new_callback_url)
+
+    # now we have access through the temporary database. Let's perform a post.
+    monkeypatch.setattr("orc_api.schemas.cross_section.get_session", lambda: session_cross_section)
+    monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_cross_section)
+
+    cross_section_update = cross_section_response.sync_remote(site=1)
+    print(cross_section_update)

--- a/tests/test_schemas/test_cross_section_schemas.py
+++ b/tests/test_schemas/test_cross_section_schemas.py
@@ -45,6 +45,7 @@ def test_cross_section_sync(session_cross_section, cross_section_response, monke
 
     monkeypatch.setattr(CallbackUrlResponse, "post", mock_post)
     monkeypatch.setattr("orc_api.schemas.cross_section.get_session", lambda: session_cross_section)
+    monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_cross_section)
     cross_section_update = cross_section_response.sync_remote(site=site)
     assert cross_section_update.remote_id == 3
     assert cross_section_update.sync_status == SyncStatus.SYNCED

--- a/tests/test_schemas/test_cross_section_schemas.py
+++ b/tests/test_schemas/test_cross_section_schemas.py
@@ -27,7 +27,7 @@ def test_cross_section_sync(session_cross_section, cross_section_response, monke
     # let's assume we are posting on site 1
     site = 1
 
-    def mock_post(self, endpoint: str, data=None, files=None):
+    def mock_post(self, endpoint: str, data=None, json=None, files=None):
         class MockResponse:
             status_code = 201
 
@@ -44,8 +44,8 @@ def test_cross_section_sync(session_cross_section, cross_section_response, monke
         return MockResponse()
 
     monkeypatch.setattr(CallbackUrlResponse, "post", mock_post)
-    monkeypatch.setattr("orc_api.schemas.cross_section.get_session", lambda: session_cross_section)
     monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_cross_section)
+    monkeypatch.setattr("orc_api.schemas.cross_section.get_session", lambda: session_cross_section)
     cross_section_update = cross_section_response.sync_remote(site=site)
     assert cross_section_update.remote_id == 3
     assert cross_section_update.sync_status == SyncStatus.SYNCED
@@ -56,13 +56,14 @@ def test_cross_section_sync_not_permitted(session_cross_section, cross_section_r
     # let's assume we are posting on site 1
     site = 1
 
-    def mock_post(self, endpoint: str, data=None, files=None):
+    def mock_post(self, endpoint: str, data=None, json=None, files=None):
         class MockResponse:
             status_code = 403
 
         return MockResponse()
 
     monkeypatch.setattr(CallbackUrlResponse, "post", mock_post)
+    monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_cross_section)
     monkeypatch.setattr("orc_api.schemas.cross_section.get_session", lambda: session_cross_section)
     with pytest.raises(ValueError, match="Remote update failed with status code 403."):
         _ = cross_section_response.sync_remote(site=site)

--- a/tests/test_schemas/test_recipe_schemas.py
+++ b/tests/test_schemas/test_recipe_schemas.py
@@ -29,7 +29,7 @@ def test_recipe_sync(session_recipe, recipe_response, monkeypatch):
     # let's assume we are posting on institute 1
     institute = 1
 
-    def mock_post(self, endpoint: str, data=None, files=None):
+    def mock_post(self, endpoint: str, data=None, json=None, files=None):
         class MockResponse:
             status_code = 201
 
@@ -44,6 +44,7 @@ def test_recipe_sync(session_recipe, recipe_response, monkeypatch):
         return MockResponse()
 
     monkeypatch.setattr(CallbackUrlResponse, "post", mock_post)
+    monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_recipe)
     monkeypatch.setattr("orc_api.schemas.recipe.get_session", lambda: session_recipe)
     recipe_update = recipe_response.sync_remote(institute=institute)
     assert recipe_update.remote_id == 4
@@ -55,14 +56,15 @@ def test_recipe_sync_not_permitted(session_recipe, recipe_response, monkeypatch)
     # let's assume we are posting on site 1
     institute = 1
 
-    def mock_post(self, endpoint: str, data=None, files=None):
+    def mock_post(self, endpoint: str, data=None, json=None, files=None):
         class MockResponse:
             status_code = 403
 
         return MockResponse()
 
     monkeypatch.setattr(CallbackUrlResponse, "post", mock_post)
-    monkeypatch.setattr("orc_api.schemas.cross_section.get_session", lambda: session_recipe)
+    monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_recipe)
+    monkeypatch.setattr("orc_api.schemas.recipe.get_session", lambda: session_recipe)
     with pytest.raises(ValueError, match="Remote update failed with status code 403."):
         _ = recipe_response.sync_remote(institute=institute)
 

--- a/tests/test_schemas/test_recipe_schemas.py
+++ b/tests/test_schemas/test_recipe_schemas.py
@@ -26,7 +26,7 @@ def test_recipe_schema(recipe_response):
 
 def test_recipe_sync(session_recipe, recipe_response, monkeypatch):
     """Test for syncing a cross-section to remote API (real response is mocked)."""
-    # let's assume we are posting on site 1
+    # let's assume we are posting on institute 1
     institute = 1
 
     def mock_post(self, endpoint: str, data=None, files=None):

--- a/tests/test_schemas/test_recipe_schemas.py
+++ b/tests/test_schemas/test_recipe_schemas.py
@@ -1,13 +1,104 @@
+import os
+
+import pytest
 from sqlalchemy.orm import Session
 
-from orc_api.db import Recipe
+from orc_api import crud
+from orc_api.db import CallbackUrl, Recipe, SyncStatus
+from orc_api.schemas.callback_url import CallbackUrlCreate, CallbackUrlResponse
 from orc_api.schemas.recipe import RecipeResponse
 
 
-def test_recipe_schema(session_recipe: Session):
+@pytest.fixture
+def recipe_response(session_recipe: Session):
     # retrieve recipe
     r_rec = session_recipe.query(Recipe).first()
-    r = RecipeResponse.model_validate(r_rec)
+    return RecipeResponse.model_validate(r_rec)
+
+
+def test_recipe_schema(recipe_response):
+    # retrieve recipe
+    r = recipe_response
     assert r.id == 1
     assert r.name == "some recipe"
     assert "video" in r.data
+
+
+def test_recipe_sync(session_recipe, recipe_response, monkeypatch):
+    """Test for syncing a cross-section to remote API (real response is mocked)."""
+    # let's assume we are posting on site 1
+    institute = 1
+
+    def mock_post(self, endpoint: str, data=None, files=None):
+        class MockResponse:
+            status_code = 201
+
+            def json(self):
+                return {
+                    "id": 4,
+                    "name": recipe_response.name,
+                    "data": recipe_response.data,
+                    "institute": institute,
+                }
+
+        return MockResponse()
+
+    monkeypatch.setattr(CallbackUrlResponse, "post", mock_post)
+    monkeypatch.setattr("orc_api.schemas.recipe.get_session", lambda: session_recipe)
+    recipe_update = recipe_response.sync_remote(institute=institute)
+    assert recipe_update.remote_id == 4
+    assert recipe_update.sync_status == SyncStatus.SYNCED
+
+
+def test_recipe_sync_not_permitted(session_recipe, recipe_response, monkeypatch):
+    """Test for syncing a cross-section to remote API (real response is mocked)."""
+    # let's assume we are posting on site 1
+    institute = 1
+
+    def mock_post(self, endpoint: str, data=None, files=None):
+        class MockResponse:
+            status_code = 403
+
+        return MockResponse()
+
+    monkeypatch.setattr(CallbackUrlResponse, "post", mock_post)
+    monkeypatch.setattr("orc_api.schemas.cross_section.get_session", lambda: session_recipe)
+    with pytest.raises(ValueError, match="Remote update failed with status code 403."):
+        _ = recipe_response.sync_remote(institute=institute)
+
+
+@pytest.mark.skipif(
+    not os.getenv("LIVEORC_URL") or not os.getenv("LIVEORC_EMAIL") or not os.getenv("LIVEORC_PASSWORD"),
+    reason="This test requires LIVEORC_URL, LIVEORC_EMAIL and LIVEORC_PASSWORD to be set",
+)
+def test_recipe_sync_real_server(session_recipe, recipe_response, monkeypatch):
+    """Test for syncing a cross-section to a real remote API.
+
+    This requires setting LIVEORC_URL, LIVEORC_EMAIL and LIVEORC_PASSWORD environment variables.
+    You must have access to the remote API to run this test and have site=1 available on the remote API.
+    """
+    # first patch the liveorc access
+    callback_create = CallbackUrlCreate(
+        url=os.getenv("LIVEORC_URL"),
+        user=os.getenv("LIVEORC_EMAIL"),
+        password=os.getenv("LIVEORC_PASSWORD"),
+    )
+    tokens = callback_create.get_tokens().json()
+    new_callback_dict = callback_create.model_dump(exclude_none=True, mode="json", exclude={"id", "password", "user"})
+    # add our newly found information from LiveORC server
+    new_callback_dict.update(
+        {
+            "token_access": tokens["access"],
+            "token_refresh": tokens["refresh"],
+            "token_expiration": callback_create.get_token_expiration(),
+        }
+    )
+    new_callback_url = CallbackUrl(**new_callback_dict)
+    crud.callback_url.add(session_recipe, new_callback_url)
+
+    # now we have access through the temporary database. Let's perform a post.
+    monkeypatch.setattr("orc_api.schemas.recipe.get_session", lambda: session_recipe)
+    monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_recipe)
+
+    recipe_update = recipe_response.sync_remote(institute=1)
+    print(recipe_update)

--- a/tests/test_schemas/test_time_series_schemas.py
+++ b/tests/test_schemas/test_time_series_schemas.py
@@ -1,0 +1,53 @@
+import os
+
+import pytest
+from sqlalchemy.orm import Session
+
+from orc_api import crud
+from orc_api.db import CallbackUrl, TimeSeries
+from orc_api.schemas.callback_url import CallbackUrlCreate
+from orc_api.schemas.time_series import TimeSeriesResponse
+
+
+@pytest.fixture
+def time_series_response(session_video_with_config: Session):
+    # retrieve recipe
+    ts_rec = session_video_with_config.query(TimeSeries).first()
+    return TimeSeriesResponse.model_validate(ts_rec)
+
+
+@pytest.mark.skipif(
+    not os.getenv("LIVEORC_URL") or not os.getenv("LIVEORC_EMAIL") or not os.getenv("LIVEORC_PASSWORD"),
+    reason="This test requires LIVEORC_URL, LIVEORC_EMAIL and LIVEORC_PASSWORD to be set",
+)
+def test_time_series_sync_real_server(session_video_with_config, time_series_response, monkeypatch):
+    """Test for syncing a time series record to a real remote API.
+
+    This requires setting LIVEORC_URL, LIVEORC_EMAIL and LIVEORC_PASSWORD environment variables.
+    You must have access to the remote API to run this test and have site=1 available on the remote API.
+    """
+    # first patch the liveorc access
+    callback_create = CallbackUrlCreate(
+        url=os.getenv("LIVEORC_URL"),
+        user=os.getenv("LIVEORC_EMAIL"),
+        password=os.getenv("LIVEORC_PASSWORD"),
+    )
+    tokens = callback_create.get_tokens().json()
+    new_callback_dict = callback_create.model_dump(exclude_none=True, mode="json", exclude={"id", "password", "user"})
+    # add our newly found information from LiveORC server
+    new_callback_dict.update(
+        {
+            "token_access": tokens["access"],
+            "token_refresh": tokens["refresh"],
+            "token_expiration": callback_create.get_token_expiration(),
+        }
+    )
+    new_callback_url = CallbackUrl(**new_callback_dict)
+    crud.callback_url.add(session_video_with_config, new_callback_url)
+
+    # now we have access through the temporary database. Let's perform a post.
+    monkeypatch.setattr("orc_api.schemas.time_series.get_session", lambda: session_video_with_config)
+    monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_video_with_config)
+
+    time_series_update = time_series_response.sync_remote(site=1)
+    print(time_series_update)

--- a/tests/test_schemas/test_time_series_schemas.py
+++ b/tests/test_schemas/test_time_series_schemas.py
@@ -21,7 +21,7 @@ def test_time_series_sync(session_video_with_config, time_series_response, monke
     # let's assume we are posting on site 1
     site = 1
 
-    def mock_post(self, endpoint: str, data=None, files=None):
+    def mock_post(self, endpoint: str, data=None, json=None, files=None):
         class MockResponse:
             status_code = 201
 
@@ -37,6 +37,7 @@ def test_time_series_sync(session_video_with_config, time_series_response, monke
 
     monkeypatch.setattr(CallbackUrlResponse, "post", mock_post)
     monkeypatch.setattr("orc_api.schemas.time_series.get_session", lambda: session_video_with_config)
+    monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_video_with_config)
     time_series_update = time_series_response.sync_remote(site=site)
     assert time_series_update.remote_id == 10
     assert time_series_update.sync_status == SyncStatus.SYNCED
@@ -47,13 +48,14 @@ def test_time_series_sync_not_permitted(session_video_with_config, time_series_r
     # let's assume we are posting on site 1
     site = 1
 
-    def mock_post(self, endpoint: str, data=None, files=None):
+    def mock_post(self, endpoint: str, data=None, json=None, files=None):
         class MockResponse:
             status_code = 403
 
         return MockResponse()
 
     monkeypatch.setattr(CallbackUrlResponse, "post", mock_post)
+    monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_video_with_config)
     monkeypatch.setattr("orc_api.schemas.time_series.get_session", lambda: session_video_with_config)
     with pytest.raises(ValueError, match="Remote update failed with status code 403."):
         _ = time_series_response.sync_remote(site=site)

--- a/tests/test_schemas/test_video_config_schemas.py
+++ b/tests/test_schemas/test_video_config_schemas.py
@@ -1,4 +1,11 @@
+import os
+
 import numpy as np
+import pytest
+
+from orc_api import crud
+from orc_api.db import CallbackUrl, SyncStatus
+from orc_api.schemas.callback_url import CallbackUrlCreate, CallbackUrlResponse
 
 
 def test_video_config_schema(video_config_response):
@@ -29,3 +36,105 @@ def test_video_config_recipe_cleaned(video_config_response):
     ][-1]
     orig_z = vc.cross_section.features["features"][0]["geometry"]["coordinates"][-1]
     assert np.isclose(new_z - orig_z, 1)
+
+
+def test_recipe_sync(session_video_config, video_config_response, monkeypatch):
+    """Test for syncing a cross-section to remote API (real response is mocked)."""
+    # let's assume we are posting on site 1
+    institute = 1
+    site = 1
+
+    def mock_post(self, endpoint: str, data=None, files=None):
+        class MockResponse:
+            status_code = 201
+
+            def json(self):
+                return {
+                    "id": 5,
+                    "name": video_config_response.name,
+                    "camera_config": {"some": "data"},
+                    "recipe": 4,
+                    "profile": 3,
+                    "server": 0,
+                }
+
+        return MockResponse()
+
+    # ensure that only relevant parts of code are tested.
+    monkeypatch.setattr(CallbackUrlResponse, "post", mock_post)
+    # we here already store recipe and cross section in database with SYNCED statusses. This prevents syncing.
+    video_config_response.recipe.sync_status = SyncStatus.SYNCED
+    video_config_response.recipe.remote_id = 4
+    crud.recipe.update(session_video_config, 1, video_config_response.recipe.model_dump(exclude_none=True))
+    video_config_response.cross_section.sync_status = SyncStatus.SYNCED
+    video_config_response.cross_section.remote_id = 3
+    crud.cross_section.update(
+        session_video_config, 1, video_config_response.cross_section.model_dump(exclude_none=True)
+    )
+
+    # ensure that we load the right session
+    monkeypatch.setattr("orc_api.schemas.video_config.get_session", lambda: session_video_config)
+    video_config_update = video_config_response.sync_remote(institute=institute, site=site)
+
+    # check if remote ids are coming through in the response model
+    assert video_config_update.recipe.remote_id == 4
+    assert video_config_update.cross_section.remote_id == 3
+    assert video_config_update.remote_id == 5
+    assert video_config_update.sync_status == SyncStatus.SYNCED
+
+
+def test_video_config_sync_not_permitted(session_video_config, video_config_response, monkeypatch):
+    """Test for syncing a cross-section to remote API (real response is mocked)."""
+    # let's assume we are posting on site 1
+    institute = 1
+    site = 1
+
+    def mock_post(self, endpoint: str, data=None, files=None):
+        class MockResponse:
+            status_code = 403
+
+        return MockResponse()
+
+    monkeypatch.setattr(CallbackUrlResponse, "post", mock_post)
+    monkeypatch.setattr("orc_api.schemas.video_config.get_session", lambda: session_video_config)
+    with pytest.raises(ValueError, match="Remote update failed with status code 403."):
+        _ = video_config_response.sync_remote(institute=institute, site=site)
+
+
+@pytest.mark.skipif(
+    not os.getenv("LIVEORC_URL") or not os.getenv("LIVEORC_EMAIL") or not os.getenv("LIVEORC_PASSWORD"),
+    reason="This test requires LIVEORC_URL, LIVEORC_EMAIL and LIVEORC_PASSWORD to be set",
+)
+def test_video_config_sync_real_server(session_video_config, video_config_response, monkeypatch):
+    """Test for syncing a full video configuration to a real remote API.
+
+    This requires setting LIVEORC_URL, LIVEORC_EMAIL and LIVEORC_PASSWORD environment variables.
+    You must have access to the remote API to run this test and have site=1 available on the remote API.
+    """
+    # first patch the liveorc access
+    callback_create = CallbackUrlCreate(
+        url=os.getenv("LIVEORC_URL"),
+        user=os.getenv("LIVEORC_EMAIL"),
+        password=os.getenv("LIVEORC_PASSWORD"),
+    )
+    tokens = callback_create.get_tokens().json()
+    new_callback_dict = callback_create.model_dump(exclude_none=True, mode="json", exclude={"id", "password", "user"})
+    # add our newly found information from LiveORC server
+    new_callback_dict.update(
+        {
+            "token_access": tokens["access"],
+            "token_refresh": tokens["refresh"],
+            "token_expiration": callback_create.get_token_expiration(),
+        }
+    )
+    new_callback_url = CallbackUrl(**new_callback_dict)
+    crud.callback_url.add(session_video_config, new_callback_url)
+
+    # now we have access through the temporary database. Let's perform a post.
+    monkeypatch.setattr("orc_api.schemas.video_config.get_session", lambda: session_video_config)
+    monkeypatch.setattr("orc_api.schemas.recipe.get_session", lambda: session_video_config)
+    monkeypatch.setattr("orc_api.schemas.cross_section.get_session", lambda: session_video_config)
+    monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_video_config)
+
+    video_config_update = video_config_response.sync_remote(institute=1, site=1)
+    print(video_config_update)

--- a/tests/test_schemas/test_video_config_schemas.py
+++ b/tests/test_schemas/test_video_config_schemas.py
@@ -44,7 +44,7 @@ def test_recipe_sync(session_video_config, video_config_response, monkeypatch):
     institute = 1
     site = 1
 
-    def mock_post(self, endpoint: str, data=None, files=None):
+    def mock_post(self, endpoint: str, data=None, json=None, files=None):
         class MockResponse:
             status_code = 201
 
@@ -73,6 +73,7 @@ def test_recipe_sync(session_video_config, video_config_response, monkeypatch):
     )
 
     # ensure that we load the right session
+    monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_video_config)
     monkeypatch.setattr("orc_api.schemas.video_config.get_session", lambda: session_video_config)
     video_config_update = video_config_response.sync_remote(institute=institute, site=site)
 
@@ -89,13 +90,14 @@ def test_video_config_sync_not_permitted(session_video_config, video_config_resp
     institute = 1
     site = 1
 
-    def mock_post(self, endpoint: str, data=None, files=None):
+    def mock_post(self, endpoint: str, data=None, json=None, files=None):
         class MockResponse:
             status_code = 403
 
         return MockResponse()
 
     monkeypatch.setattr(CallbackUrlResponse, "post", mock_post)
+    monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_video_config)
     monkeypatch.setattr("orc_api.schemas.video_config.get_session", lambda: session_video_config)
     with pytest.raises(ValueError, match="Remote update failed with status code 403."):
         _ = video_config_response.sync_remote(institute=institute, site=site)

--- a/tests/test_schemas/test_video_schemas.py
+++ b/tests/test_schemas/test_video_schemas.py
@@ -47,7 +47,7 @@ def test_video_sync(session_video_with_config, video_response, monkeypatch):
     site = 1
     institute = 1
 
-    def mock_post(self, endpoint: str, data=None, files=None):
+    def mock_post(self, endpoint: str, data=None, json=None, files=None):
         class MockResponse:
             status_code = 201
 
@@ -72,8 +72,8 @@ def test_video_sync(session_video_with_config, video_response, monkeypatch):
     crud.time_series.update(session_video_with_config, 1, video_response.time_series.model_dump(exclude_none=True))
 
     monkeypatch.setattr(CallbackUrlResponse, "post", mock_post)
-    monkeypatch.setattr("orc_api.schemas.video.get_session", lambda: session_video_with_config)
     monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_video_with_config)
+    monkeypatch.setattr("orc_api.schemas.video.get_session", lambda: session_video_with_config)
     video_update = video_response.sync_remote(
         base_path=sample_data.get_hommerich_pyorc_files(), site=site, institute=institute
     )
@@ -87,15 +87,15 @@ def test_video_sync_not_permitted(session_video_with_config, video_response, mon
     institute = 1
     site = 1
 
-    def mock_post(self, endpoint: str, data=None, files=None):
+    def mock_post(self, endpoint: str, data=None, json=None, files=None):
         class MockResponse:
             status_code = 403
 
         return MockResponse()
 
     monkeypatch.setattr(CallbackUrlResponse, "post", mock_post)
-    monkeypatch.setattr("orc_api.schemas.video.get_session", lambda: session_video_with_config)
     monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_video_with_config)
+    monkeypatch.setattr("orc_api.schemas.video.get_session", lambda: session_video_with_config)
     with pytest.raises(ValueError, match="Remote update failed with status code 403."):
         _ = video_response.sync_remote(
             base_path=sample_data.get_hommerich_pyorc_files(), institute=institute, site=site
@@ -132,12 +132,12 @@ def test_video_sync_real_server(session_video_with_config, video_response, monke
     crud.callback_url.add(session_video_with_config, new_callback_url)
 
     # now we have access through the temporary database. Let's perform a post.
+    monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_video_with_config)
     monkeypatch.setattr("orc_api.schemas.time_series.get_session", lambda: session_video_with_config)
     monkeypatch.setattr("orc_api.schemas.video.get_session", lambda: session_video_with_config)
     monkeypatch.setattr("orc_api.schemas.video_config.get_session", lambda: session_video_with_config)
     monkeypatch.setattr("orc_api.schemas.cross_section.get_session", lambda: session_video_with_config)
     monkeypatch.setattr("orc_api.schemas.recipe.get_session", lambda: session_video_with_config)
-    monkeypatch.setattr("orc_api.schemas.base.get_session", lambda: session_video_with_config)
 
     video_update = video_response.sync_remote(base_path=sample_data.get_hommerich_pyorc_files(), site=1, institute=1)
     print(video_update)

--- a/tests/test_schemas/test_video_schemas.py
+++ b/tests/test_schemas/test_video_schemas.py
@@ -23,3 +23,14 @@ def test_video_run(
     # check if video got updated also
     video = session_video_config.query(models.Video).filter(models.Video.id == 1).first()
     assert video.image is not None
+
+
+@pytest.mark.skip(reason="Testing full video run without water level only done on interactive request.")
+def test_video_run_no_waterlevel(video_response_no_ts, session_video_config, monkeypatch):
+    monkeypatch.setattr("orc_api.schemas.video.get_session", lambda: session_video_config)
+    assert video_response_no_ts.time_series is None
+    video_response_no_ts.run(base_path=sample_data.get_hommerich_pyorc_files())
+    assert video_response_no_ts.time_series is not None
+    assert video_response_no_ts.status == models.VideoStatus.DONE
+    assert len(video_response_no_ts.get_netcdf_files(base_path=sample_data.get_hommerich_pyorc_files())) > 0
+    assert video_response_no_ts.get_discharge_file(base_path=sample_data.get_hommerich_pyorc_files()) is not None


### PR DESCRIPTION
This fixes #25 with all POST synchronisation options (from device to server) implemented

NOT implemented are GET functions, e.g. in cases where a user wants to retrieve data and store this on the device. Currently this is not foreseen, but this may change dependent on development of use cases.