### PR TITLE
111 shutdown device after task if this is set in daemon settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## [0.3.3] - 2025-10-07
+This is a **preproduction alpha release**, not yet fit for production and operational environments.
+This release should only be used for:
+- testing
+- piloting
+- evaluation purposes
+
+Feedback and bug reports are highly appreciated to improve future versions.
+
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+- Daemon setting for shutdown after task now works as expected. When checked and daemon is activated, the OS will
+  shutdown after a single task is completed. Older tasks that were not finished will NOT be reprocessed in this case.
+### Security
+
+
 ## [0.3.2] - 2025-10-01
 This is a **preproduction alpha release**, not yet fit for production and operational environments.
 This release should only be used for:

--- a/orc_api/schedulers.py
+++ b/orc_api/schedulers.py
@@ -66,9 +66,13 @@ def schedule_video_checker(scheduler, logger, session, app):
     settings = crud.settings.get(session)
     dm = crud.disk_management.get(session)
 
+    process_queue_videos = True
     # settings must be provided AND active
     if settings and dm:
         if settings.active:
+            if settings.shutdown_after_task:
+                # prevent that older videos are being processed
+                process_queue_videos = False
             # validate the settings model instance
             settings = SettingsResponse.model_validate(settings)
             logger.info(
@@ -92,3 +96,4 @@ def schedule_video_checker(scheduler, logger, session, app):
             logger.info("Daemon settings found, but not activated. Activate the daemon for automated processing.")
     else:
         logger.info("No daemon settings available, ORC-OS will run interactively only.")
+    return process_queue_videos

--- a/orc_api/schemas/settings.py
+++ b/orc_api/schemas/settings.py
@@ -112,11 +112,12 @@ class SettingsResponse(SettingsBase):
                     )
                 # move video to queue
                 video_response = await queue.process_video_submission(
-                    session,
-                    video_response,
-                    logger,
-                    app.state.executor,
-                    UPLOAD_DIRECTORY,
+                    session=session,
+                    video=video_response,
+                    logger=logger,
+                    executor=app.state.executor,
+                    upload_directory=UPLOAD_DIRECTORY,
+                    shutdown_after_task=self.shutdown_after_task if self.shutdown_after_task else False,
                 )
                 # whatever happens, remove the file if not successful, prevent clogging
                 os.remove(tmp_file)

--- a/orc_api/schemas/video.py
+++ b/orc_api/schemas/video.py
@@ -227,6 +227,7 @@ class VideoResponse(VideoBase, RemoteModel):
             raise Exception("Error running video, VideoStatus set to ERROR.")
         # shutdown if this is set
         if shutdown_after_task:
+            logger.info("Shutting down after daemon task...Bye bye :-)")
             subprocess.call("sudo shutdown -h now", shell=True)
         return
 

--- a/orc_api/schemas/video.py
+++ b/orc_api/schemas/video.py
@@ -3,6 +3,7 @@
 import glob
 import json
 import os
+import subprocess
 from datetime import datetime
 from typing import Optional
 
@@ -124,7 +125,7 @@ class VideoResponse(VideoBase, RemoteModel):
         else:
             return True, "Ready"
 
-    def run(self, session: Session, base_path: str, prefix: str = ""):
+    def run(self, session: Session, base_path: str, prefix: str = "", shutdown_after_task: bool = False):
         """Run video."""
         # update state first
         try:
@@ -224,6 +225,9 @@ class VideoResponse(VideoBase, RemoteModel):
                 logger.error(f"Error syncing video to remote site: {e_sync}")
         if self.status == models.VideoStatus.ERROR:
             raise Exception("Error running video, VideoStatus set to ERROR.")
+        # shutdown if this is set
+        if shutdown_after_task:
+            subprocess.call("sudo shutdown -h now", shell=True)
         return
 
     def sync_remote(self, session: Session, base_path: str, site: int, sync_file: bool = True, sync_image: bool = True):

--- a/orc_api/utils/queue.py
+++ b/orc_api/utils/queue.py
@@ -12,7 +12,12 @@ from orc_api.schemas.video import VideoPatch, VideoResponse
 
 
 async def process_video_submission(
-    session: Session, video: VideoResponse, logger: Logger, executor: Executor, upload_directory: str
+    session: Session,
+    video: VideoResponse,
+    logger: Logger,
+    executor: Executor,
+    upload_directory: str,
+    shutdown_after_task: bool = False,
 ):
     """Process and submit a video for execution.
 
@@ -31,6 +36,8 @@ async def process_video_submission(
         An executor instance for running asynchronous tasks related to video execution.
     upload_directory : str
         Absolute path of the directory where video files are uploaded.
+    shutdown_after_task : bool, optional
+        if set True, hard-shutdown the device after the task is processed. Requires sudo rights without password.
 
     Raises
     ------
@@ -57,7 +64,8 @@ async def process_video_submission(
             # Submit the video for execution
             try:
                 # video.run(upload_directory)
-                executor.submit(video.run, session, upload_directory)
+                executor.submit(video.run, session, upload_directory, "", shutdown_after_task)
+                logger.info(f"Video {video.file} submitted to the executor.")
             except Exception as e:
                 logger.error(f"Failed to submit video {video.file}: {str(e)}")
                 raise HTTPException(status_code=500, detail="Failed to process the video submission.")


### PR DESCRIPTION
## Issue addressed
Fixes #111

## Explanation
Made sure that when a video is run from the daemon settings, and `settings.shutdown_after_task` is True, the device will shutdown entirely after one single task.

## General Checklist
- [x] Updated tests or added new tests
- [x] Fork is up-to-date with `main`
- [x] Tests pass
- [x] Front end functionalities tested
- [x] Updated documentation
- [x] Updated CHANGELOG.md


